### PR TITLE
Add missing v8 exceptions

### DIFF
--- a/src/binding.cpp
+++ b/src/binding.cpp
@@ -1224,6 +1224,22 @@ const v8::Value* v8__Exception__Error(const v8::String& message) {
     return local_to_ptr(v8::Exception::Error(ptr_to_local(&message)));
 }
 
+const v8::Value* v8__Exception__TypeError(const v8::String& message) {
+    return local_to_ptr(v8::Exception::TypeError(ptr_to_local(&message)));
+}
+
+const v8::Value* v8__Exception__SyntaxError(const v8::String& message) {
+    return local_to_ptr(v8::Exception::SyntaxError(ptr_to_local(&message)));
+}
+
+const v8::Value* v8__Exception__ReferenceError(const v8::String& message) {
+    return local_to_ptr(v8::Exception::ReferenceError(ptr_to_local(&message)));
+}
+
+const v8::Value* v8__Exception__RangeError(const v8::String& message) {
+    return local_to_ptr(v8::Exception::RangeError(ptr_to_local(&message)));
+}
+
 const v8::StackTrace* v8__Exception__GetStackTrace(const v8::Value& exception) {
     return local_to_ptr(v8::Exception::GetStackTrace(ptr_to_local(&exception)));
 }

--- a/src/binding.h
+++ b/src/binding.h
@@ -512,6 +512,10 @@ void v8__Object__SetAlignedPointerInInternalField(
 
 // Exception
 const Value* v8__Exception__Error(const String* message);
+const Value* v8__Exception__TypeError(const String* message);
+const Value* v8__Exception__SyntaxError(const String* message);
+const Value* v8__Exception__ReferenceError(const String* message);
+const Value* v8__Exception__RangeError(const String* message);
 const StackTrace* v8__Exception__GetStackTrace(const Value* exception);
 const Message* v8__Exception__CreateMessage(
     Isolate* isolate,


### PR DESCRIPTION
TypeError
SyntaxError
ReferenceError
RangeError

see https://v8docs.nodesource.com/node-9.11/da/d6a/classv8_1_1_exception.html

Signed-off-by: Francis Bouvier <francis.bouvier@gmail.com>